### PR TITLE
Correct license in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ setup(
     install_requires=REQUIRED,
     extras_require=EXTRAS,
     include_package_data=True,
-    license="MIT",
+    license="BUSL",
     zip_safe=False,
     keywords="AMR, Metering, smart meters, MDM, dlms, cosem",
     classifiers=CLASSIFIERS,


### PR DESCRIPTION
dlms-cosem is released under the Business Source License 1.1 not the MIT license.